### PR TITLE
Directus initial schema setup

### DIFF
--- a/directus/schema.yaml
+++ b/directus/schema.yaml
@@ -1,0 +1,515 @@
+version: 1
+directus: 11.1.0
+vendor: sqlite
+collections:
+  - collection: clubs
+    meta:
+      accountability: all
+      archive_app_filter: true
+      archive_field: null
+      archive_value: null
+      collapse: open
+      collection: clubs
+      color: null
+      display_template: null
+      group: leagueData
+      hidden: false
+      icon: null
+      item_duplication_fields: null
+      note: null
+      preview_url: null
+      singleton: false
+      sort: 1
+      sort_field: null
+      translations: null
+      unarchive_value: null
+      versioning: false
+    schema:
+      name: clubs
+  - collection: leagueData
+    meta:
+      accountability: all
+      archive_app_filter: true
+      archive_field: null
+      archive_value: null
+      collapse: open
+      collection: leagueData
+      color: null
+      display_template: null
+      group: null
+      hidden: false
+      icon: folder
+      item_duplication_fields: null
+      note: null
+      preview_url: null
+      singleton: false
+      sort: 1
+      sort_field: null
+      translations: null
+      unarchive_value: null
+      versioning: false
+  - collection: teams
+    meta:
+      accountability: all
+      archive_app_filter: true
+      archive_field: null
+      archive_value: null
+      collapse: open
+      collection: teams
+      color: null
+      display_template: null
+      group: leagueData
+      hidden: false
+      icon: null
+      item_duplication_fields: null
+      note: null
+      preview_url: null
+      singleton: false
+      sort: 2
+      sort_field: null
+      translations: null
+      unarchive_value: null
+      versioning: false
+    schema:
+      name: teams
+  - collection: websiteContent
+    meta:
+      accountability: all
+      archive_app_filter: true
+      archive_field: null
+      archive_value: null
+      collapse: open
+      collection: websiteContent
+      color: null
+      display_template: null
+      group: null
+      hidden: false
+      icon: folder
+      item_duplication_fields: null
+      note: null
+      preview_url: null
+      singleton: false
+      sort: 2
+      sort_field: null
+      translations: null
+      unarchive_value: null
+      versioning: false
+fields:
+  - collection: clubs
+    field: id
+    type: uuid
+    meta:
+      collection: clubs
+      conditions: null
+      display: null
+      display_options: null
+      field: id
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: true
+      required: false
+      sort: 1
+      special:
+        - uuid
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: id
+      table: clubs
+      data_type: char
+      default_value: null
+      max_length: 36
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: true
+      is_primary_key: true
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: clubs
+    field: dateCreated
+    type: timestamp
+    meta:
+      collection: clubs
+      conditions: null
+      display: datetime
+      display_options:
+        relative: true
+      field: dateCreated
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      sort: 2
+      special:
+        - cast-timestamp
+        - date-created
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: dateCreated
+      table: clubs
+      data_type: datetime
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: clubs
+    field: dateUpdated
+    type: timestamp
+    meta:
+      collection: clubs
+      conditions: null
+      display: datetime
+      display_options:
+        relative: true
+      field: dateUpdated
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      sort: 3
+      special:
+        - cast-timestamp
+        - date-updated
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: dateUpdated
+      table: clubs
+      data_type: datetime
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: clubs
+    field: name
+    type: string
+    meta:
+      collection: clubs
+      conditions: null
+      display: null
+      display_options: null
+      field: name
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: true
+      sort: 4
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: name
+      table: clubs
+      data_type: varchar
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: clubs
+    field: location
+    type: string
+    meta:
+      collection: clubs
+      conditions: null
+      display: null
+      display_options: null
+      field: location
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: false
+      sort: 5
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: location
+      table: clubs
+      data_type: varchar
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: teams
+    field: id
+    type: uuid
+    meta:
+      collection: teams
+      conditions: null
+      display: null
+      display_options: null
+      field: id
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: true
+      required: false
+      sort: 1
+      special:
+        - uuid
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: id
+      table: teams
+      data_type: char
+      default_value: null
+      max_length: 36
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: true
+      is_primary_key: true
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: teams
+    field: dateCreated
+    type: timestamp
+    meta:
+      collection: teams
+      conditions: null
+      display: datetime
+      display_options:
+        relative: true
+      field: dateCreated
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      sort: 2
+      special:
+        - cast-timestamp
+        - date-created
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: dateCreated
+      table: teams
+      data_type: datetime
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: teams
+    field: dateUpdated
+    type: timestamp
+    meta:
+      collection: teams
+      conditions: null
+      display: datetime
+      display_options:
+        relative: true
+      field: dateUpdated
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      sort: 3
+      special:
+        - cast-timestamp
+        - date-updated
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: dateUpdated
+      table: teams
+      data_type: datetime
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: teams
+    field: name
+    type: string
+    meta:
+      collection: teams
+      conditions: null
+      display: null
+      display_options: null
+      field: name
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: true
+      sort: 4
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: name
+      table: teams
+      data_type: varchar
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: teams
+    field: club
+    type: string
+    meta:
+      collection: teams
+      conditions: null
+      display: null
+      display_options: null
+      field: club
+      group: null
+      hidden: false
+      interface: select-dropdown-m2o
+      note: null
+      options:
+        enableCreate: false
+      readonly: false
+      required: true
+      sort: 5
+      special:
+        - m2o
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: club
+      table: teams
+      data_type: char
+      default_value: null
+      max_length: 36
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: clubs
+      foreign_key_column: id
+relations:
+  - collection: teams
+    field: club
+    related_collection: clubs
+    meta:
+      junction_field: null
+      many_collection: teams
+      many_field: club
+      one_allowed_collections: null
+      one_collection: clubs
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: null
+      sort_field: null
+    schema:
+      table: teams
+      column: club
+      foreign_key_table: clubs
+      foreign_key_column: id
+      constraint_name: null
+      on_update: NO ACTION
+      on_delete: NO ACTION

--- a/directus/schema.yaml
+++ b/directus/schema.yaml
@@ -12,7 +12,7 @@ collections:
       collection: clubs
       color: null
       display_template: null
-      group: leagueData
+      group: null
       hidden: false
       icon: null
       item_duplication_fields: null
@@ -26,28 +26,54 @@ collections:
       versioning: false
     schema:
       name: clubs
-  - collection: leagueData
+  - collection: leagues
     meta:
       accountability: all
       archive_app_filter: true
       archive_field: null
       archive_value: null
       collapse: open
-      collection: leagueData
+      collection: leagues
       color: null
       display_template: null
       group: null
       hidden: false
-      icon: folder
+      icon: null
       item_duplication_fields: null
       note: null
       preview_url: null
       singleton: false
-      sort: 1
+      sort: 3
       sort_field: null
       translations: null
       unarchive_value: null
       versioning: false
+    schema:
+      name: leagues
+  - collection: matches
+    meta:
+      accountability: all
+      archive_app_filter: true
+      archive_field: null
+      archive_value: null
+      collapse: open
+      collection: matches
+      color: null
+      display_template: null
+      group: null
+      hidden: false
+      icon: null
+      item_duplication_fields: null
+      note: null
+      preview_url: null
+      singleton: false
+      sort: 4
+      sort_field: null
+      translations: null
+      unarchive_value: null
+      versioning: false
+    schema:
+      name: matches
   - collection: teams
     meta:
       accountability: all
@@ -58,7 +84,7 @@ collections:
       collection: teams
       color: null
       display_template: null
-      group: leagueData
+      group: null
       hidden: false
       icon: null
       item_duplication_fields: null
@@ -72,28 +98,6 @@ collections:
       versioning: false
     schema:
       name: teams
-  - collection: websiteContent
-    meta:
-      accountability: all
-      archive_app_filter: true
-      archive_field: null
-      archive_value: null
-      collapse: open
-      collection: websiteContent
-      color: null
-      display_template: null
-      group: null
-      hidden: false
-      icon: folder
-      item_duplication_fields: null
-      note: null
-      preview_url: null
-      singleton: false
-      sort: 2
-      sort_field: null
-      translations: null
-      unarchive_value: null
-      versioning: false
 fields:
   - collection: clubs
     field: id
@@ -135,7 +139,7 @@ fields:
       foreign_key_table: null
       foreign_key_column: null
   - collection: clubs
-    field: dateCreated
+    field: date_created
     type: timestamp
     meta:
       collection: clubs
@@ -143,7 +147,7 @@ fields:
       display: datetime
       display_options:
         relative: true
-      field: dateCreated
+      field: date_created
       group: null
       hidden: true
       interface: datetime
@@ -160,7 +164,7 @@ fields:
       validation_message: null
       width: half
     schema:
-      name: dateCreated
+      name: date_created
       table: clubs
       data_type: datetime
       default_value: null
@@ -176,7 +180,7 @@ fields:
       foreign_key_table: null
       foreign_key_column: null
   - collection: clubs
-    field: dateUpdated
+    field: date_updated
     type: timestamp
     meta:
       collection: clubs
@@ -184,7 +188,7 @@ fields:
       display: datetime
       display_options:
         relative: true
-      field: dateUpdated
+      field: date_updated
       group: null
       hidden: true
       interface: datetime
@@ -201,7 +205,7 @@ fields:
       validation_message: null
       width: half
     schema:
-      name: dateUpdated
+      name: date_updated
       table: clubs
       data_type: datetime
       default_value: null
@@ -246,7 +250,7 @@ fields:
       max_length: 255
       numeric_precision: null
       numeric_scale: null
-      is_nullable: true
+      is_nullable: false
       is_unique: false
       is_primary_key: false
       is_generated: false
@@ -292,6 +296,757 @@ fields:
       has_auto_increment: false
       foreign_key_table: null
       foreign_key_column: null
+  - collection: leagues
+    field: id
+    type: uuid
+    meta:
+      collection: leagues
+      conditions: null
+      display: null
+      display_options: null
+      field: id
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: true
+      required: false
+      sort: 1
+      special:
+        - uuid
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: id
+      table: leagues
+      data_type: char
+      default_value: null
+      max_length: 36
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: true
+      is_primary_key: true
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: leagues
+    field: date_created
+    type: timestamp
+    meta:
+      collection: leagues
+      conditions: null
+      display: datetime
+      display_options:
+        relative: true
+      field: date_created
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      sort: 2
+      special:
+        - cast-timestamp
+        - date-created
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: date_created
+      table: leagues
+      data_type: datetime
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: leagues
+    field: date_updated
+    type: timestamp
+    meta:
+      collection: leagues
+      conditions: null
+      display: datetime
+      display_options:
+        relative: true
+      field: date_updated
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      sort: 3
+      special:
+        - cast-timestamp
+        - date-updated
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: date_updated
+      table: leagues
+      data_type: datetime
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: leagues
+    field: title
+    type: string
+    meta:
+      collection: leagues
+      conditions: null
+      display: null
+      display_options: null
+      field: title
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options: null
+      readonly: false
+      required: true
+      sort: 4
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: title
+      table: leagues
+      data_type: varchar
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: leagues
+    field: start_date
+    type: date
+    meta:
+      collection: leagues
+      conditions: null
+      display: null
+      display_options: null
+      field: start_date
+      group: null
+      hidden: false
+      interface: datetime
+      note: null
+      options: null
+      readonly: false
+      required: true
+      sort: 5
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: start_date
+      table: leagues
+      data_type: date
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: leagues
+    field: end_date
+    type: date
+    meta:
+      collection: leagues
+      conditions: null
+      display: null
+      display_options: null
+      field: end_date
+      group: null
+      hidden: false
+      interface: datetime
+      note: null
+      options: null
+      readonly: false
+      required: false
+      sort: 6
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: end_date
+      table: leagues
+      data_type: date
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: matches
+    field: id
+    type: uuid
+    meta:
+      collection: matches
+      conditions: null
+      display: null
+      display_options: null
+      field: id
+      group: null
+      hidden: true
+      interface: input
+      note: null
+      options: null
+      readonly: true
+      required: false
+      sort: 1
+      special:
+        - uuid
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: id
+      table: matches
+      data_type: char
+      default_value: null
+      max_length: 36
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: true
+      is_primary_key: true
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: matches
+    field: date_created
+    type: timestamp
+    meta:
+      collection: matches
+      conditions: null
+      display: datetime
+      display_options:
+        relative: true
+      field: date_created
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      sort: 2
+      special:
+        - cast-timestamp
+        - date-created
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: date_created
+      table: matches
+      data_type: datetime
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: matches
+    field: date_updated
+    type: timestamp
+    meta:
+      collection: matches
+      conditions: null
+      display: datetime
+      display_options:
+        relative: true
+      field: date_updated
+      group: null
+      hidden: true
+      interface: datetime
+      note: null
+      options: null
+      readonly: true
+      required: false
+      sort: 3
+      special:
+        - cast-timestamp
+        - date-updated
+      translations: null
+      validation: null
+      validation_message: null
+      width: half
+    schema:
+      name: date_updated
+      table: matches
+      data_type: datetime
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: matches
+    field: team_1
+    type: string
+    meta:
+      collection: matches
+      conditions: null
+      display: null
+      display_options: null
+      field: team_1
+      group: null
+      hidden: false
+      interface: select-dropdown-m2o
+      note: null
+      options:
+        enableCreate: false
+        template: '{{name}}'
+      readonly: false
+      required: true
+      sort: 5
+      special:
+        - m2o
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: team_1
+      table: matches
+      data_type: char
+      default_value: null
+      max_length: 36
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: teams
+      foreign_key_column: id
+  - collection: matches
+    field: team_2
+    type: string
+    meta:
+      collection: matches
+      conditions: null
+      display: null
+      display_options: null
+      field: team_2
+      group: null
+      hidden: false
+      interface: select-dropdown-m2o
+      note: null
+      options:
+        enableCreate: false
+        template: '{{name}}'
+      readonly: false
+      required: true
+      sort: 6
+      special:
+        - m2o
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: team_2
+      table: matches
+      data_type: char
+      default_value: null
+      max_length: 36
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: teams
+      foreign_key_column: id
+  - collection: matches
+    field: league
+    type: string
+    meta:
+      collection: matches
+      conditions: null
+      display: null
+      display_options: null
+      field: league
+      group: null
+      hidden: false
+      interface: select-dropdown-m2o
+      note: null
+      options:
+        enableCreate: false
+      readonly: false
+      required: true
+      sort: 4
+      special:
+        - m2o
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: league
+      table: matches
+      data_type: char
+      default_value: null
+      max_length: 36
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: leagues
+      foreign_key_column: id
+  - collection: matches
+    field: team_1_score
+    type: integer
+    meta:
+      collection: matches
+      conditions: null
+      display: null
+      display_options: null
+      field: team_1_score
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options:
+        min: 0
+      readonly: false
+      required: false
+      sort: 7
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: team_1_score
+      table: matches
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: matches
+    field: team_2_score
+    type: integer
+    meta:
+      collection: matches
+      conditions: null
+      display: null
+      display_options: null
+      field: team_2_score
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options:
+        min: 0
+      readonly: false
+      required: false
+      sort: 8
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: team_2_score
+      table: matches
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: matches
+    field: ref_team
+    type: string
+    meta:
+      collection: matches
+      conditions: null
+      display: null
+      display_options: null
+      field: ref_team
+      group: null
+      hidden: false
+      interface: select-dropdown-m2o
+      note: null
+      options:
+        enableCreate: false
+      readonly: false
+      required: false
+      sort: 9
+      special:
+        - m2o
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: ref_team
+      table: matches
+      data_type: char
+      default_value: null
+      max_length: 36
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: teams
+      foreign_key_column: id
+  - collection: matches
+    field: order
+    type: integer
+    meta:
+      collection: matches
+      conditions: null
+      display: null
+      display_options: null
+      field: order
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options:
+        min: 1
+      readonly: false
+      required: false
+      sort: 10
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: order
+      table: matches
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: matches
+    field: round
+    type: integer
+    meta:
+      collection: matches
+      conditions: null
+      display: null
+      display_options: null
+      field: round
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options:
+        min: 1
+      readonly: false
+      required: false
+      sort: 11
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: round
+      table: matches
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: matches
+    field: court
+    type: integer
+    meta:
+      collection: matches
+      conditions: null
+      display: null
+      display_options: null
+      field: court
+      group: null
+      hidden: false
+      interface: input
+      note: null
+      options:
+        min: 1
+      readonly: false
+      required: false
+      sort: 12
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: court
+      table: matches
+      data_type: integer
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: matches
+    field: date
+    type: date
+    meta:
+      collection: matches
+      conditions: null
+      display: null
+      display_options: null
+      field: date
+      group: null
+      hidden: false
+      interface: datetime
+      note: null
+      options: null
+      readonly: false
+      required: false
+      sort: 13
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: date
+      table: matches
+      data_type: date
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
   - collection: teams
     field: id
     type: uuid
@@ -332,7 +1087,7 @@ fields:
       foreign_key_table: null
       foreign_key_column: null
   - collection: teams
-    field: dateCreated
+    field: date_created
     type: timestamp
     meta:
       collection: teams
@@ -340,7 +1095,7 @@ fields:
       display: datetime
       display_options:
         relative: true
-      field: dateCreated
+      field: date_created
       group: null
       hidden: true
       interface: datetime
@@ -357,7 +1112,7 @@ fields:
       validation_message: null
       width: half
     schema:
-      name: dateCreated
+      name: date_created
       table: teams
       data_type: datetime
       default_value: null
@@ -373,7 +1128,7 @@ fields:
       foreign_key_table: null
       foreign_key_column: null
   - collection: teams
-    field: dateUpdated
+    field: date_updated
     type: timestamp
     meta:
       collection: teams
@@ -381,7 +1136,7 @@ fields:
       display: datetime
       display_options:
         relative: true
-      field: dateUpdated
+      field: date_updated
       group: null
       hidden: true
       interface: datetime
@@ -398,7 +1153,7 @@ fields:
       validation_message: null
       width: half
     schema:
-      name: dateUpdated
+      name: date_updated
       table: teams
       data_type: datetime
       default_value: null
@@ -429,7 +1184,7 @@ fields:
       options: null
       readonly: false
       required: true
-      sort: 4
+      sort: 5
       special: null
       translations: null
       validation: null
@@ -437,6 +1192,95 @@ fields:
       width: full
     schema:
       name: name
+      table: teams
+      data_type: varchar
+      default_value: null
+      max_length: 255
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: false
+      is_unique: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: teams
+    field: ball_type
+    type: json
+    meta:
+      collection: teams
+      conditions: null
+      display: null
+      display_options: null
+      field: ball_type
+      group: null
+      hidden: false
+      interface: select-multiple-checkbox
+      note: null
+      options:
+        choices:
+          - text: Foam
+            value: foam
+          - text: Cloth
+            value: cloth
+      readonly: false
+      required: true
+      sort: 6
+      special:
+        - cast-json
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: ball_type
+      table: teams
+      data_type: json
+      default_value: null
+      max_length: null
+      numeric_precision: null
+      numeric_scale: null
+      is_nullable: true
+      is_unique: false
+      is_primary_key: false
+      is_generated: false
+      generation_expression: null
+      has_auto_increment: false
+      foreign_key_table: null
+      foreign_key_column: null
+  - collection: teams
+    field: player_base
+    type: string
+    meta:
+      collection: teams
+      conditions: null
+      display: null
+      display_options: null
+      field: player_base
+      group: null
+      hidden: false
+      interface: select-radio
+      note: null
+      options:
+        choices:
+          - text: Male
+            value: male
+          - text: Female
+            value: female
+          - text: Mixed
+            value: mixed
+      readonly: false
+      required: true
+      sort: 7
+      special: null
+      translations: null
+      validation: null
+      validation_message: null
+      width: full
+    schema:
+      name: player_base
       table: teams
       data_type: varchar
       default_value: null
@@ -457,8 +1301,9 @@ fields:
     meta:
       collection: teams
       conditions: null
-      display: null
-      display_options: null
+      display: related-values
+      display_options:
+        template: '{{name}}'
       field: club
       group: null
       hidden: false
@@ -466,9 +1311,10 @@ fields:
       note: null
       options:
         enableCreate: false
+        template: '{{name}}'
       readonly: false
       required: true
-      sort: 5
+      sort: 4
       special:
         - m2o
       translations: null
@@ -492,6 +1338,90 @@ fields:
       foreign_key_table: clubs
       foreign_key_column: id
 relations:
+  - collection: matches
+    field: team_1
+    related_collection: teams
+    meta:
+      junction_field: null
+      many_collection: matches
+      many_field: team_1
+      one_allowed_collections: null
+      one_collection: teams
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: null
+      sort_field: null
+    schema:
+      table: matches
+      column: team_1
+      foreign_key_table: teams
+      foreign_key_column: id
+      constraint_name: null
+      on_update: NO ACTION
+      on_delete: NO ACTION
+  - collection: matches
+    field: team_2
+    related_collection: teams
+    meta:
+      junction_field: null
+      many_collection: matches
+      many_field: team_2
+      one_allowed_collections: null
+      one_collection: teams
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: null
+      sort_field: null
+    schema:
+      table: matches
+      column: team_2
+      foreign_key_table: teams
+      foreign_key_column: id
+      constraint_name: null
+      on_update: NO ACTION
+      on_delete: NO ACTION
+  - collection: matches
+    field: league
+    related_collection: leagues
+    meta:
+      junction_field: null
+      many_collection: matches
+      many_field: league
+      one_allowed_collections: null
+      one_collection: leagues
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: null
+      sort_field: null
+    schema:
+      table: matches
+      column: league
+      foreign_key_table: leagues
+      foreign_key_column: id
+      constraint_name: null
+      on_update: NO ACTION
+      on_delete: NO ACTION
+  - collection: matches
+    field: ref_team
+    related_collection: teams
+    meta:
+      junction_field: null
+      many_collection: matches
+      many_field: ref_team
+      one_allowed_collections: null
+      one_collection: teams
+      one_collection_field: null
+      one_deselect_action: nullify
+      one_field: null
+      sort_field: null
+    schema:
+      table: matches
+      column: ref_team
+      foreign_key_table: teams
+      foreign_key_column: id
+      constraint_name: null
+      on_update: NO ACTION
+      on_delete: SET NULL
   - collection: teams
     field: club
     related_collection: clubs


### PR DESCRIPTION
# Context

[Directus](https://directus.io) has been chosen for our data management system. The intention is to host it such that admins can edit data and the main site application from read from it on the server-side.

# Changes

- Add initial schema, covering:
  - Leagues
  - Clubs
  - Teams
  - Matches

# Design

We have chosen not to enforce too much validation around teams and which leagues they are tied to, as this adds a lot of complexity around required data models and would still not be "perfect". Instead we will rely on good data curation and perhaps automated reporting later down the line.